### PR TITLE
Lesser Heal Obliteration

### DIFF
--- a/code/modules/spells/roguetown/cleric.dm
+++ b/code/modules/spells/roguetown/cleric.dm
@@ -85,12 +85,12 @@
 			var/mob/living/carbon/C = target
 			var/obj/item/bodypart/affecting = C.get_bodypart(check_zone(user.zone_selected))
 			if(affecting)
-				if(affecting.heal_damage(20, 20, 0, null, FALSE))
+				if(affecting.heal_damage(0, 0, 0, null, FALSE))
 					C.update_damage_overlays()
 				if(affecting.heal_wounds(50))
 					C.update_damage_overlays()
 		else
-			target.adjustBruteLoss(-5)
+			target.adjustBruteLoss(0)
 			target.adjustFireLoss(-5)
 		target.adjustToxLoss(-5)
 		target.adjustOxyLoss(-5)


### PR DESCRIPTION
Its a crutch that circumnavigates sleeping in a bed. Removed the healing aspect, can only be used to stabilize wounds such as bleeding. Bed gameplay is essential as it is a moment of vulnerability one has to experience in order to heal (more rp with group). This should also tone down the strength of the paladin.


https://github.com/Osmos123/BLACKSTONEBal/assets/126647931/21fd7cf3-bb05-473a-8eb3-1af5bc18c630

